### PR TITLE
altering dependencies in reqm.txt file to fix index.html serving

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Flask==0.12.3
-Jinja2==2.7.2
-MarkupSafe==0.21
-Werkzeug==0.10.4
-gunicorn==19.5.0
+Flask==1.1.4
+Jinja2
+MarkupSafe==2.0.1
+Werkzeug
+gunicorn


### PR DESCRIPTION
Per this [issue](https://github.com/vrabbi/tap-oss/issues/5), I was having trouble getting this demo to work against the tap-oss platform.  I updated flask and pinned markupsafe==2.0.1, as advised [here](https://serverfault.com/questions/1094062).  Built and ran locally, which appeared to fix.